### PR TITLE
Add Vagrantfile to provide a development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ This project is divided into 2 components:
 
 # Setup
 
+## Using Vagrant (recommended)
+
+Go to the `vagrant/` sub-directory to install a development environement for `kvm-vmi`
+
+## Manually
+
 Unfortunately, it is not possible to compile the KVM modules as an `out-of-tree`
 build. You will have to compile and install a new kernel along with the new modules.
 
@@ -22,6 +28,7 @@ build. You will have to compile and install a new kernel along with the new modu
 - Reboot
 - Make sure you loaded the modified kernel module (`make reload`)
 - Go to `nitro` to setup the userland component and intercept syscalls
+- Compile the modified version of `qemu` if you intend to analyze syscall events with `libvmi`
 
 
 # References

--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,0 +1,3 @@
+.vagrant/
+provision/playbook.retry
+venv/

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,59 @@
+# Vagrant
+
+Here you will find a `Vagrantfile` to build a development environment for `kvm-vmi`.
+
+# Requirements
+
+- `vagrant`
+- `vagrant-libvirt` plugin
+- `ansible >= 2.2.1.0`
+
+# Setup
+
+Tune the Vagrantfile configuration to your needs.
+
+Default config :
+- `libvirt.memory = 4G` (at least `2G` is required)
+- `libvirt.cpus = 2`
+
+Update vagrant plugin to the latest version:
+~~~
+$ vagrant plugin update vagrant-libvirt
+~~~
+
+- Run `vagrant up --provider=libvirt`
+- Once vagrant is done creating and provisioning the box, **reboot the box** (from libvirt) to
+run the new kernel with the modified KVM modules, and run `vagrant ssh` to get a shell in the VM.
+- Start the test vm with `virsh start nitro_win7x64` (or use `virt-manager` connection)
+- go to `/data/kvm-vmi/nitro` and you can play with **Nitro** !
+
+# Virt-manager
+
+You can use `virt-manager` to view and manage VMs in the vagrant box.
+SSH is open for password authentication.
+Specify the `root` account with the password `vagrant`.
+
+To have the graphical display working, you need to change the `Display Spice/VNC` configuration:
+set `address` to `All interfaces`.
+
+# Using NFS
+
+You can make use of Vagrant's `NFS` to mount the root of the repo in the vagrant box.
+This gives you several advantages:
+- the second partition where the kernel was cloned and compiled is not needed (30G)
+- you can edit your files directly on your host, with your favorite IDE
+
+You need to open you firewall for `NFS`. The following commands should make it work for a `Vagrant` box
+to access your host `NFS` server:
+
+~~~
+firewall-cmd --permanent --add-service=nfs
+firewall-cmd --permanent --add-service=rpc-bind
+firewall-cmd --permanent --add-service=mountd
+firewall-cmd --reload
+~~~
+
+To enable it, replace the value of `use_nfs` by `true` in the `Vagrantfile`:
+~~~
+use_nfs = true
+~~~

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,35 @@
+Vagrant.configure(2) do |config|
+    config.vm.box = "debian/jessie64"
+
+    # enable NFS here
+    use_nfs = false
+
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+
+    if use_nfs == true
+        config.vm.synced_folder "..", "/vagrant",
+            :nfs => true,
+            :nfs_version => 4,
+            :nfs_udp => false,
+            :linux__nfs_options => ['rw','no_subtree_check','no_root_squash','async']
+
+    end
+
+    config.vm.provider :libvirt do |libvirt|
+        libvirt.cpus = 2
+        libvirt.memory = 4096
+        libvirt.driver = "kvm"
+        libvirt.nested = true
+        if use_nfs == false
+            libvirt.machine_virtual_size = 40
+        end
+    end
+
+    config.vm.provision "ansible" do |ansible|
+        if use_nfs == true
+            ansible.playbook = "provision_nfs/playbook.yml"
+        else
+            ansible.playbook = "provision/playbook.yml"
+        end
+    end
+end

--- a/vagrant/provision/kvm.yml
+++ b/vagrant/provision/kvm.yml
@@ -1,0 +1,91 @@
+---
+- name: add backports
+  lineinfile:
+    dest: /etc/apt/sources.list
+    line: 'deb http://ftp.debian.org/debian jessie-backports main'
+    insertafter: EOF
+
+- name: update cache
+  apt:
+    update_cache: yes
+
+- name: install linux source and build deps
+  apt:
+    name: "{{ item }}"
+  with_items:
+    - linux-source-4.9
+    - libssl-dev
+    - fakeroot
+    - dpkg-dev
+
+- name: create /data/src dir
+  file:
+    path: /data/src
+    state: directory
+    owner: vagrant
+    group: vagrant
+
+- name: extract linux kernel
+  shell: tar xf /usr/src/linux-source-4.9.tar.xz -C /data/src
+  become: false
+
+- name: extract kernel config amd64
+  shell: xz -dc /usr/src/linux-config-4.9/config.amd64_none_amd64.xz > /data/src/linux-source-4.9/.config
+  become: false
+
+- name: enable KVM
+  shell: cd /data/src/linux-source-4.9 && ./scripts/config --module KVM
+  become: false
+
+- name: enable KVM_INTEL
+  shell: cd /data/src/linux-source-4.9 && ./scripts/config --module KVM_INTEL
+  become: false
+
+- name: enable KVM_AMD
+  shell: cd /data/src/linux-source-4.9 && ./scripts/config --module KVM_AMD
+  become: false
+
+- name: enable CONFIG_MEMCG
+  shell: cd /data/src/linux-source-4.9 && ./scripts/config --enable CONFIG_MEMCG
+  become: false
+
+- name: enable iptables NAT
+  shell: cd /data/src/linux-source-4.9 && ./scripts/config --module IP_NF_NAT
+  become: false
+
+- name: fetch all branches
+  shell: cd /data/kvm-vmi/kvm && git fetch --all
+  become: false
+
+- name: checkout linux-vmi
+  shell: cd /data/kvm-vmi/kvm && git checkout linux-vmi
+  become: false
+
+- name: checkout linux-v4.9
+  shell: cd /data/kvm-vmi/kvm && git checkout linux-v4.9
+  become: false
+
+- name: git diff and apply nitro patch
+  shell: cd /data/kvm-vmi/kvm && git diff linux-v4.9 linux-vmi | git -C /data/src/linux-source-4.9 apply
+  become: false
+
+- name: make olddefconfig for silent config
+  shell: cd /data/src/linux-source-4.9 && make olddefconfig
+  become: false
+
+- name: append -nitro to kernel version string
+  lineinfile: 
+    dest: /data/src/linux-source-4.9/Makefile
+    regexp: '^EXTRAVERSION ='
+    line: 'EXTRAVERSION = -nitro'
+  become: false
+
+- name: build kernel debian packages
+  shell: cd /data/src/linux-source-4.9 && make -j4 deb-pkg
+  become: false
+
+- name: install kernel packages
+  shell: dpkg -i /data/src/*.deb
+
+- name: clean kernel sources to get free space
+  shell: cd /data/src/linux-source-4.9 && make mrproper

--- a/vagrant/provision/libvmi.yml
+++ b/vagrant/provision/libvmi.yml
@@ -1,0 +1,50 @@
+---
+- name: install build tools
+  package:
+    name: "{{ item }}"
+  with_items:
+    - git
+    - build-essential
+    - gcc
+    - libtool
+    - automake
+    - pkg-config
+    - check
+    - libglib2.0-dev
+    - libvirt-dev
+    - bison
+    - flex
+    - python-dev
+
+- name: clone libvmi
+  git:
+    repo: https://github.com/libvmi/libvmi
+    version: master
+    dest: libvmi
+    force: yes
+  become: false
+
+- name: enable max debug for libvmi
+  lineinfile:
+    dest: "/home/{{ ansible_user }}/libvmi/libvmi/debug.h"
+    regexp: '.*#define VMI_DEBUG.*'
+    line: '#define VMI_DEBUG __VMI_DEBUG_ALL'
+  become: false
+
+- name: configure libvmi
+  shell: cd libvmi && ./autogen.sh && ./configure --prefix=/usr --disable-xen --enable-kvm
+  become: false
+
+- name: build libvmi
+  shell: cd libvmi && make
+  become: false
+
+- name: install libvmi
+  shell: cd "/home/{{ ansible_user }}/libvmi" && make install
+
+  #- name: build pyvmi
+  #  shell: cd libvmi/tools/pyvmi && python setup.py build
+  #  become: false
+  #
+  #- name: install pyvmi
+  #  shell: cd "/home/{{ ansible_user }}/libvmi/tools/pyvmi" && python setup.py install

--- a/vagrant/provision/nitro.yml
+++ b/vagrant/provision/nitro.yml
@@ -1,0 +1,39 @@
+---
+- name: install Nitro dependencies
+  package:
+    name: "{{ item }}"
+  with_items:
+    - python3
+    - python3-pip
+    - python3-libvirt
+    - python3-docopt
+    - python3-zmq
+    - python-docopt
+    - python-zmq
+
+- name: install Pebble
+  shell: pip3 install pebble
+
+- name: install ioctl-opt
+  shell: pip3 install ioctl_opt
+
+# rekall
+- name: install dependencies for rekall
+  package:
+    name: "{{ item }}"
+  with_items:
+    - python-pip
+    - python-dev
+    - ncurses-dev
+
+- name: updating pip for rekall
+  shell: pip install --upgrade setuptools pip wheel
+
+- name: install rekall
+  shell: pip install rekall
+
+# libvmi
+- include: libvmi.yml
+
+- name: add user to kvm group to access /dev/kvm
+  shell: usermod -a -G kvm vagrant

--- a/vagrant/provision/partition.yml
+++ b/vagrant/provision/partition.yml
@@ -1,0 +1,34 @@
+---
+- name: install parted
+  package:
+    name: "{{ item }}"
+  with_items:
+    - parted
+
+- name: create a new primary partition with free space left
+  shell: (echo n ; echo p; echo 2; echo ; echo ; echo w) | fdisk /dev/vda || true
+
+- name: reread partition table
+  shell: partprobe
+
+- name: create ext4 filesystem
+  shell: mkfs.ext4 /dev/vda2
+
+- name: create /data
+  file:
+    path: /data
+    state: directory
+
+- name: mount the new partition on /data
+  mount:
+    src: /dev/vda2
+    name: /data
+    state: mounted
+    fstype: ext4
+
+- name: force ownership of /data to vagrant
+  file:
+    path: /data
+    state: directory
+    owner: vagrant
+    group: vagrant

--- a/vagrant/provision/playbook.yml
+++ b/vagrant/provision/playbook.yml
@@ -1,0 +1,27 @@
+---
+- hosts: default
+  become: true
+  tasks:
+    - name: install useful tools
+      package:
+        name: "{{ item }}"
+      with_items:
+        - git
+        - htop
+        - vim
+
+    - include: partition.yml
+    - include: remote.yml
+
+    - name: clone kvm-vmi repo
+      shell: cd /data && git clone https://github.com/KVM-VMI/kvm-vmi
+      become: false
+
+    - name: clone submodules
+      shell: cd /data/kvm-vmi/kvm && git submodule update --init
+      become: false
+
+    - include: kvm.yml
+    - include: nitro.yml
+    - include: qemu.yml
+    - include: test_vm.yml

--- a/vagrant/provision/qemu.yml
+++ b/vagrant/provision/qemu.yml
@@ -1,0 +1,25 @@
+---
+- name: install QEMU dependencies
+  package:
+    name: "{{ item }}"
+  with_items:
+    - pkg-config
+    - zlib1g-dev
+    - libglib2.0-dev
+    - dh-autoreconf
+    - libspice-server-dev
+
+- name: clone pixman submodule
+  shell: cd /data/kvm-vmi/qemu && git submodule update --init pixman
+  become: false
+
+- name: configure QEMU
+  shell: cd /data/kvm-vmi/qemu && ./configure --target-list=x86_64-softmmu --enable-spice --prefix=/usr
+  become: false
+
+- name: build QEMU
+  shell: cd /data/kvm-vmi/qemu && make -j4
+  become: false
+
+- name: install QEMU
+  shell: cd /data/kvm-vmi/qemu && make install

--- a/vagrant/provision/remote.yml
+++ b/vagrant/provision/remote.yml
@@ -1,0 +1,27 @@
+---
+- name: enable password authentification in SSH
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: '^ChallengeResponseAuthentication'
+    line: 'ChallengeResponseAuthentication yes'
+
+- name: enable root login in SSH
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: '^PermitRootLogin'
+    line: 'PermitRootLogin yes'
+
+- name: restart SSH server
+  shell: systemctl restart ssh
+
+# python -c 'import crypt; print crypt.crypt("vagrant", "vagrant-salt$$")'
+- name: set password for vagrant account
+  user:
+    name: vagrant
+    password: vaqRzE48Dulhs
+
+
+- name: set password for root account
+  user:
+    name: root
+    password: vaqRzE48Dulhs

--- a/vagrant/provision/test_vm.yml
+++ b/vagrant/provision/test_vm.yml
@@ -1,0 +1,12 @@
+---
+- name: add user to libvirt group
+  shell: usermod -a -G libvirt vagrant
+
+- name: enable default network as autostart
+  shell: virsh -c qemu:///system net-autostart default
+
+- name: build test vm
+  shell: cd /data/kvm-vmi/nitro/tests/packer-windows/ && ./packer build windows_7_x64.json
+
+- name: import in libvirt
+  shell: cd /data/kvm-vmi/nitro/tests/ && ./import_libvirt.py packer-windows/output-qemu/win7x64

--- a/vagrant/provision_nfs/kvm.yml
+++ b/vagrant/provision_nfs/kvm.yml
@@ -1,0 +1,65 @@
+---
+- name: add backports
+  lineinfile:
+    dest: /etc/apt/sources.list
+    line: 'deb http://ftp.debian.org/debian jessie-backports main'
+    insertafter: EOF
+
+- name: update cache
+  apt:
+    update_cache: yes
+
+- name: install linux source and build deps
+  apt:
+    name: "{{ item }}"
+  with_items:
+    - linux-source-4.9
+    - libssl-dev
+    - fakeroot
+    - dpkg-dev
+
+- name: clean sources
+  shell: cd /vagrant/kvm && make mrproper
+  become: false
+
+- name: extract kernel config amd64
+  shell: xz -dc /usr/src/linux-config-4.9/config.amd64_none_amd64.xz > /vagrant/kvm/.config
+  become: false
+
+- name: enable KVM
+  shell: cd /vagrant/kvm && ./scripts/config --module KVM
+  become: false
+
+- name: enable KVM_INTEL
+  shell: cd /vagrant/kvm && ./scripts/config --module KVM_INTEL
+  become: false
+
+- name: enable KVM_AMD
+  shell: cd /vagrant/kvm && ./scripts/config --module KVM_AMD
+  become: false
+
+- name: enable CONFIG_MEMCG
+  shell: cd /vagrant/kvm && ./scripts/config --enable CONFIG_MEMCG
+  become: false
+
+- name: enable iptables NAT
+  shell: cd /vagrant/kvm && ./scripts/config --module IP_NF_NAT
+  become: false
+
+- name: make olddefconfig for silent config
+  shell: cd /vagrant/kvm && make olddefconfig
+  become: false
+
+- name: append -nitro to kernel version string
+  lineinfile: 
+    dest: /vagrant/kvm/Makefile
+    regexp: '^EXTRAVERSION ='
+    line: 'EXTRAVERSION = -nitro'
+  become: false
+
+- name: build kernel debian packages
+  shell: cd /vagrant/kvm && make -j4 deb-pkg
+  become: false
+
+- name: install kernel packages
+  shell: dpkg -i /vagrant/*.deb

--- a/vagrant/provision_nfs/libvmi.yml
+++ b/vagrant/provision_nfs/libvmi.yml
@@ -1,0 +1,50 @@
+---
+- name: install build tools
+  package:
+    name: "{{ item }}"
+  with_items:
+    - git
+    - build-essential
+    - gcc
+    - libtool
+    - automake
+    - pkg-config
+    - check
+    - libglib2.0-dev
+    - libvirt-dev
+    - bison
+    - flex
+    - python-dev
+
+- name: clone libvmi
+  git:
+    repo: https://github.com/libvmi/libvmi
+    version: master
+    dest: libvmi
+    force: yes
+  become: false
+
+- name: enable max debug for libvmi
+  lineinfile:
+    dest: "/home/{{ ansible_user }}/libvmi/libvmi/debug.h"
+    regexp: '.*#define VMI_DEBUG.*'
+    line: '#define VMI_DEBUG __VMI_DEBUG_ALL'
+  become: false
+
+- name: configure libvmi
+  shell: cd libvmi && ./autogen.sh && ./configure --prefix=/usr --disable-xen --enable-kvm
+  become: false
+
+- name: build libvmi
+  shell: cd libvmi && make
+  become: false
+
+- name: install libvmi
+  shell: cd "/home/{{ ansible_user }}/libvmi" && make install
+
+  #- name: build pyvmi
+  #  shell: cd libvmi/tools/pyvmi && python setup.py build
+  #  become: false
+  #
+  #- name: install pyvmi
+  #  shell: cd "/home/{{ ansible_user }}/libvmi/tools/pyvmi" && python setup.py install

--- a/vagrant/provision_nfs/nitro.yml
+++ b/vagrant/provision_nfs/nitro.yml
@@ -1,0 +1,39 @@
+---
+- name: install Nitro dependencies
+  package:
+    name: "{{ item }}"
+  with_items:
+    - python3
+    - python3-pip
+    - python3-libvirt
+    - python3-docopt
+    - python3-zmq
+    - python-docopt
+    - python-zmq
+
+- name: install Pebble
+  shell: pip3 install pebble
+
+- name: install ioctl-opt
+  shell: pip3 install ioctl_opt
+
+# rekall
+- name: install dependencies for rekall
+  package:
+    name: "{{ item }}"
+  with_items:
+    - python-pip
+    - python-dev
+    - ncurses-dev
+
+- name: updating pip for rekall
+  shell: pip install --upgrade setuptools pip wheel
+
+- name: install rekall
+  shell: pip install rekall
+
+# libvmi
+- include: libvmi.yml
+
+- name: add user to kvm group to access /dev/kvm
+  shell: usermod -a -G kvm vagrant

--- a/vagrant/provision_nfs/playbook.yml
+++ b/vagrant/provision_nfs/playbook.yml
@@ -1,0 +1,20 @@
+---
+- hosts: default
+  become: true
+  tasks:
+    - name: install useful tools
+      package:
+        name: "{{ item }}"
+      with_items:
+        - git
+        - htop
+        - vim
+
+    - name: clean previous debian packages
+      shell: rm -f /vagrant/*.deb ; rm -f /vagrant/*.dsc ; rm -f /vagrant/*.changes ; rm -f /vagrant/*.tar.gz
+
+    - include: remote.yml
+    - include: kvm.yml
+    - include: nitro.yml
+    - include: qemu.yml
+    - include: test_vm.yml

--- a/vagrant/provision_nfs/qemu.yml
+++ b/vagrant/provision_nfs/qemu.yml
@@ -1,0 +1,25 @@
+---
+- name: install QEMU dependencies
+  package:
+    name: "{{ item }}"
+  with_items:
+    - pkg-config
+    - zlib1g-dev
+    - libglib2.0-dev
+    - dh-autoreconf
+    - libspice-server-dev
+
+- name: clone pixman submodule
+  shell: cd /vagrant/qemu && git submodule update --init pixman
+  become: false
+
+- name: configure QEMU
+  shell: cd /vagrant/qemu && ./configure --target-list=x86_64-softmmu --enable-spice --prefix=/usr
+  become: false
+
+- name: build QEMU
+  shell: cd /vagrant/qemu && make -j4
+  become: false
+
+- name: install QEMU
+  shell: cd /vagrant/qemu && make install

--- a/vagrant/provision_nfs/remote.yml
+++ b/vagrant/provision_nfs/remote.yml
@@ -1,0 +1,27 @@
+---
+- name: enable password authentification in SSH
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: '^ChallengeResponseAuthentication'
+    line: 'ChallengeResponseAuthentication yes'
+
+- name: enable root login in SSH
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: '^PermitRootLogin'
+    line: 'PermitRootLogin yes'
+
+- name: restart SSH server
+  shell: systemctl restart ssh
+
+# python -c 'import crypt; print crypt.crypt("vagrant", "vagrant-salt$$")'
+- name: set password for vagrant account
+  user:
+    name: vagrant
+    password: vaqRzE48Dulhs
+
+
+- name: set password for root account
+  user:
+    name: root
+    password: vaqRzE48Dulhs

--- a/vagrant/provision_nfs/test_vm.yml
+++ b/vagrant/provision_nfs/test_vm.yml
@@ -1,0 +1,15 @@
+---
+- name: add user to libvirt group
+  shell: usermod -a -G libvirt vagrant
+
+- name: enable default network as autostart
+  shell: virsh -c qemu:///system net-autostart default
+
+- name: remove old output-qemu
+  shell: cd /vagrant/nitro/tests/packer-windows/ && rm -rf output-qemu
+
+- name: build test vm
+  shell: cd /vagrant/nitro/tests/packer-windows/ && ./packer build windows_7_x64.json
+
+- name: import in libvirt
+  shell: cd /vagrant/nitro/tests/ && ./import_libvirt.py packer-windows/output-qemu/win7x64


### PR DESCRIPTION
This vagrantfile can provide a ready to use dev environement for KVM-VMI.
Check the README to use it.

- I disabled the synced folders, since `NFS` was not working, and `rsync` would make a copy of the kernel tree, which is too big for the default qcow size (`10G`). Therefore i choose to increase the default size to `40G` and to create a new partition, with the free disk space available (`30G`) in the provisioning phase with `Ansible`, in order to clone the `kvm-vmi` git repo into this partition and work from there.
- I opened the ssh server for password authentication so that we can easily connect with virt-manager and manage VMs in this box.
- `pyvmi` is not installed because of the compilation issue i have reported here -> [pyvmi extension compilation errors on Debian Jessie](https://github.com/libvmi/libvmi/issues/456)