### PR TITLE
Test vm setup

### DIFF
--- a/vagrant/provision_full/kvm.yml
+++ b/vagrant/provision_full/kvm.yml
@@ -88,3 +88,13 @@
   command: make install
   args:
     chdir: "{{ root_dir }}/kvm"
+
+- name: set nitro kernel as default
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: '^GRUB_DEFAULT'
+    line: 'GRUB_DEFAULT="Advanced options for Debian GNU/Linux>Debian GNU/Linux, with Linux 4.9.0-nitro+"'
+
+- name: update GRUB configuration
+  command: update-grub
+

--- a/vagrant/provision_full/playbook.yml
+++ b/vagrant/provision_full/playbook.yml
@@ -34,6 +34,6 @@
       when: nfs == false
 
     - include: kvm.yml
-    - include: nitro.yml
     - include: qemu.yml
+    - include: nitro.yml
     - include: test_vm.yml

--- a/vagrant/provision_full/qemu.yml
+++ b/vagrant/provision_full/qemu.yml
@@ -37,7 +37,7 @@
   become: false
 
 - name: configure QEMU
-  command: ./configure --target-list=x86_64-softmmu --enable-spice --prefix=/usr
+  command: ./configure --target-list=x86_64-softmmu --enable-spice --prefix=/usr/local
   args:
     chdir: "{{ root_dir }}/qemu"
   become: false

--- a/vagrant/provision_full/snapshot.xml
+++ b/vagrant/provision_full/snapshot.xml
@@ -1,0 +1,3 @@
+<domainsnapshot>
+    <name>base</name>
+</domainsnapshot>

--- a/vagrant/provision_full/test_vm.yml
+++ b/vagrant/provision_full/test_vm.yml
@@ -21,6 +21,45 @@
   become: no
 
 - name: import in libvirt
-  command: ./import_libvirt.py output-qemu/win7x64
+  command: ./import_libvirt.py --open-vnc output-qemu/win7x64
   args:
     chdir: "{{ root_dir }}/nitro/tests/vm_templates"
+
+- name: install python libvirt for virt module
+  package:
+    name: python-libvirt
+
+- name: start test VM
+  virt:
+    name: nitro_win7x64
+    state: running
+
+- name: wait to install windows drivers
+  pause:
+    minutes: 5
+
+- name: shutdown test VM
+  virt:
+    name: nitro_win7x64
+    state: shutdown
+
+- name: test for vm status
+  virt:
+    name: nitro_win7x64
+    command: status
+  register: result
+  until: result.status == 'shutdown'
+  delay: 5
+  retries: 60
+
+- name: remove old snapshot
+  command: virsh snapshot-delete --current nitro_win7x64
+
+- name: write domain snapshot XML
+  copy:
+    src: snapshot.xml
+    dest: /tmp/snapshot.xml
+
+- name: take new snapshot
+  command: virsh snapshot-create nitro_win7x64 --xmlfile /tmp/snapshot.xml
+

--- a/vagrant/provision_full/test_vm.yml
+++ b/vagrant/provision_full/test_vm.yml
@@ -23,6 +23,11 @@
   args:
     chdir: "{{ root_dir }}/nitro/tests/vm_templates"
 
+- name: remove output-qemu after import
+  file:
+    path: "{{ root_dir }}/nitro/tests/vm_templates/output-qemu"
+    state: absent
+
 - name: install python libvirt for virt module
   package:
     name: python-libvirt

--- a/vagrant/provision_full/test_vm.yml
+++ b/vagrant/provision_full/test_vm.yml
@@ -19,7 +19,7 @@
     chdir: "{{ root_dir }}/nitro/tests/vm_templates"
 
 - name: import in libvirt
-  command: ./import_libvirt.py --open-vnc output-qemu/win7x64
+  command: ./import_libvirt.py --open-vnc --qemu /usr/local/bin/qemu-system-x86_64 output-qemu/win7x64
   args:
     chdir: "{{ root_dir }}/nitro/tests/vm_templates"
 

--- a/vagrant/provision_full/test_vm.yml
+++ b/vagrant/provision_full/test_vm.yml
@@ -12,13 +12,11 @@
   file:
     path: "{{ root_dir }}/nitro/tests/vm_templates/output-qemu"
     state: absent
-  become: no
 
 - name: build test vm
   command: ./packer build --var-file=windows_7_x64.json windows.json
   args:
     chdir: "{{ root_dir }}/nitro/tests/vm_templates"
-  become: no
 
 - name: import in libvirt
   command: ./import_libvirt.py --open-vnc output-qemu/win7x64
@@ -28,6 +26,9 @@
 - name: install python libvirt for virt module
   package:
     name: python-libvirt
+
+- name: ensure default libvirt network is started
+  command: virsh net-start default
 
 - name: start test VM
   virt:

--- a/vagrant/provision_packaged/snapshot.xml
+++ b/vagrant/provision_packaged/snapshot.xml
@@ -1,0 +1,1 @@
+../provision_full/snapshot.xml


### PR DESCRIPTION
After upgrading to Debian stretch, the nitro kernel was not the default kernel anymore.
This fixes it.

Also some improvments when we setup the test vm:
- windows drivers are installed
- base snapshot is recreated afterwards
- VNC is listening on all interfaces