### PR TITLE
generate libvmi config entry using rekall_offset_finder

### DIFF
--- a/vagrant/provision_full/playbook_2.yml
+++ b/vagrant/provision_full/playbook_2.yml
@@ -6,4 +6,5 @@
     - include: qemu.yml
     - include: libkvmi.yml
     - include: libvmi.yml
+    - include: rekall.yml
     - include: test_vm.yml

--- a/vagrant/provision_full/rekall.yml
+++ b/vagrant/provision_full/rekall.yml
@@ -1,0 +1,31 @@
+---
+- name: install dependencies for rekall
+  package:
+    name: "{{ item }}"
+  with_items:
+    - python3-pip
+    - python3-dev
+    - ncurses-dev
+    - virtualenv
+
+- name: create venv for rekall
+  command: virtualenv -p python3 venv-rekall
+  args:
+    chdir: "/home/vagrant"
+  become: false
+
+- name: download rekall_offset_finder script
+  get_url:
+    url: 'https://raw.githubusercontent.com/libvmi/libvmi/3efb0e87c5977721c778e662aec10eb579296bfb/tools/windows-offset-finder/rekall_offset_finder.py'
+    dest: /home/vagrant/rekall_offset_finder.py
+    mode: 'u=rwx,g=rx,o=rx'
+
+- name: install rekall_offset_finder script dependencies
+  command: "./venv-rekall/bin/pip3 install {{ item }}"
+  args:
+    chdir: "/home/vagrant"
+  with_items:
+    - docopt
+    - libvirt-python
+    - rekall
+  become: false

--- a/vagrant/provision_full/test_vm.yml
+++ b/vagrant/provision_full/test_vm.yml
@@ -51,7 +51,20 @@
 
 - name: wait to install windows drivers
   pause:
-    minutes: 5
+    minutes: 2
+
+- name: extract offsets with rekall
+  command: "/home/vagrant/venv-rekall/bin/python3 /home/vagrant/rekall_offset_finder.py nitro_win7x64"
+
+- name: write libvmi.conf
+  blockinfile:
+    path: /etc/libvmi.conf
+    block: |
+      nitro_win7x64 {
+        ostype = "Windows";
+        rekall_profile = "/home/vagrant/nitro_win7x64-profile.json";
+      }
+    create: yes
 
 - name: shutdown test VM
   virt:
@@ -77,4 +90,3 @@
 
 - name: take new snapshot
   command: virsh snapshot-create nitro_win7x64 --xmlfile /tmp/snapshot.xml
-


### PR DESCRIPTION
This PR uses `rekall_offset_finder` script, available in the master branch of LibVMI to automatically generate the Rekall profile of the VM, and install the config entry in `/etc/libvmi.conf`

This way, the LibVMI examples can used immedately after `vagrant up`