### PR TITLE
enable KVM_INTROSPECTION

### DIFF
--- a/vagrant/ansible/roles/kvm/tasks/main.yml
+++ b/vagrant/ansible/roles/kvm/tasks/main.yml
@@ -39,14 +39,28 @@
     chdir: "{{ root_dir }}/kvm"
   become: false
 
-- name: enable KVMI
-  command: ./scripts/config --enable KVMI_MEM_GUEST
+# KVM_INTROSPECTION depends on REMOTE_MAPPING,
+# which depends on KSM being disabled
+- name: disable KSM
+  command: ./scripts/config --disable KSM
+  args:
+    chdir: "{{ root_dir }}/kvm"
+  become: false
+
+- name: enable REMOTE_MAPPING
+  command: ./scripts/config --enable REMOTE_MAPPING
+  args:
+    chdir: "{{ root_dir }}/kvm"
+  become: false
+
+- name: enable KVM_INTROSPECTION
+  command: ./scripts/config --enable KVM_INTROSPECTION
   args:
     chdir: "{{ root_dir }}/kvm"
   become: false
 
 - name: append -kvmi to kernel version string
-  lineinfile: 
+  lineinfile:
     dest: "{{ root_dir }}/kvm/Makefile"
     regexp: '^EXTRAVERSION ='
     line: 'EXTRAVERSION = -kvmi'


### PR DESCRIPTION
This fixes the introspection APIs not being enabled in the VM after `kvm-v5` patches.

the VM introspection APIs are not enabled by default anymore, we need to activate them.

Also remove `KVMI_MEM_GUEST`, which got renamed to `KVM_INTROSPECTION_GUEST`, as we don't use it anyway.