### PR TITLE
Fix vagrant build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# ignore make deb-pkg generated packages
+/*.diff.gz
+/*.dsc
+/*.buildinfo
+/*.changes
+/*.orig.tar.gz
+/*.deb

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure(2) do |config|
     config.vm.box = "generic/debian10"
-    config.vm.box_version = "2.0.6"
+    config.vm.box_version = "3.0.0"
     config.vm.define "kvmi"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure(2) do |config|
             :nfs_version => 4,
             :nfs_udp => false,
             # speedup NFS with custom options
-            :linux__nfs_options => ["rw", "no_subtree_check", "all_squash", "async"]
+            :linux__nfs_options => ["rw", "no_subtree_check", "all_squash"]
     end
 
     config.vm.provider "virtualbox" do |vbox, override|

--- a/vagrant/ansible/roles/kvm/tasks/main.yml
+++ b/vagrant/ansible/roles/kvm/tasks/main.yml
@@ -88,31 +88,32 @@
     chdir: "{{ root_dir }}/kvm"
   become: false
 
-- name: compile kernel
-  command: "make -j{{ ansible_processor_vcpus }} bzImage"
+- name: build kernel and make debian package
+  command: "make -j{{ ansible_processor_vcpus }} deb-pkg"
   args:
     chdir: "{{ root_dir }}/kvm"
   become: false
-
-- name: compile modules
-  command: "make -j{{ ansible_processor_vcpus }} modules"
-  args:
-    chdir: "{{ root_dir }}/kvm"
-  become: false
-
-- name: install modules
-  command: make modules_install
-  args:
-    chdir: "{{ root_dir }}/kvm"
   environment:
     # strip modules to reduces initramfs size by x10
     # otherwise /boot will be full
     INSTALL_MOD_STRIP: "1"
 
-- name: install kernel
-  command: make install
-  args:
-    chdir: "{{ root_dir }}/kvm"
+- name: find generated debian packages
+  find:
+    paths: "{{ root_dir }}"
+    patterns: "*.deb"
+  register: deb_list
+  become: false
+
+- name: install kernel debian packages
+  apt:
+    deb: "{{ item.path }}"
+    state: present
+  with_items:
+    "{{ deb_list.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+  become: true
 
 - name: set kvmi kernel as default
   lineinfile:


### PR DESCRIPTION
fix issue with QEMU build https://lkml.org/lkml/2020/5/1/640

QEMU was using 4.19 headers instead of kvmi ones