### PR TITLE
libvmi: track commit in master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Corresponding submodule branches:
 - `kvm`: `kvmi`
 - `qemu`: `kvmi`
 - `nitro`: `kvmi`
-- `libvmi`: `kvmi`
+- `libvmi`: `master`
 
 Note: the `nitro` is a legacy component and not part of `kvmi`.
 


### PR DESCRIPTION
KVM driver has been merged upstream: https://github.com/libvmi/libvmi/pull/844

Now tracking the `master` branch for libvmi submodule.