### PR TITLE
vagrant: upgrade debian Buster box to 3.0.22

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure(2) do |config|
     config.vm.box = "generic/debian10"
-    config.vm.box_version = "3.0.0"
+    config.vm.box_version = "3.0.22"
     config.vm.define "kvmi"
 
     config.vm.synced_folder ".", "/vagrant", disabled: true


### PR DESCRIPTION
upgrade to https://app.vagrantup.com/generic/boxes/debian10/versions/3.0.22