### PR TITLE
docs: remove kvmi suffix for bare-metal setup

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -228,7 +228,7 @@ $ sudo make install
 
 Reboot.
 Run `uname -a`
-You should be on kernel `5.4.24-kvmi` (`kvmi v7`)
+You should be on kernel `5.4.24+` (`kvmi v7`)
 
 
 ### QEMU


### PR DESCRIPTION
the -kvmi suffix is only added by the Ansible playbook for
vagrant-based setup.

Related: https://github.com/KVM-VMI/kvm-vmi/issues/100