### PR TITLE
vagrant: bump box to v3.6.12

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Vagrant.configure(2) do |config|
     config.vm.box = "generic/debian10"
-    config.vm.box_version = "3.4.2"
+    config.vm.box_version = "3.6.12"
     config.vm.define "kvmi"
 
     # configuration


### PR DESCRIPTION
Bump vagrant to v3.6.12 https://app.vagrantup.com/generic/boxes/debian10/versions/3.6.12