### PR TITLE
update rsync_args for rsync command

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -93,6 +93,7 @@ Vagrant.configure(2) do |config|
         # We cannot do an initial checkout on the Windows host because of filesystem limitations.
         override.vm.synced_folder "..", root_dir,
             :type => "rsync"
+            :rsync__args => ["--verbose", "--archive", "-z", "--copy-links"]
 
         # add synced folder hash
         synced_folder_hash.each do |folder, mntpnt|

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -92,7 +92,7 @@ Vagrant.configure(2) do |config|
         # since we want to do the checkout from inside the VM
         # We cannot do an initial checkout on the Windows host because of filesystem limitations.
         override.vm.synced_folder "..", root_dir,
-            :type => "rsync"
+            :type => "rsync",
             :rsync__args => ["--verbose", "--archive", "-z", "--copy-links"]
 
         # add synced folder hash


### PR DESCRIPTION
One of the default args for the rsync command is --delete. This causes the kvm folder to be emptied on the guest VM, because it is also empty on the Windows host.

See also: https://developer.hashicorp.com/vagrant/docs/synced-folders/rsync